### PR TITLE
Easy OSTF launching based on file config

### DIFF
--- a/fuel_health/config.py
+++ b/fuel_health/config.py
@@ -486,4 +486,7 @@ class NailgunConfig(object):
 
 
 def FuelConfig():
-    return NailgunConfig()
+    if 'CUSTOM_FUEL_CONFIG' in os.environ:
+        return FileConfig()
+    else:
+        return NailgunConfig()

--- a/fuel_health/test.py
+++ b/fuel_health/test.py
@@ -33,8 +33,6 @@ class BaseTestCase(unittest2.TestCase,
                    testresources.ResourcedTestCase,
                    FuelTestAssertMixin):
 
-    config = config.FuelConfig()
-
     def __init__(self, *args, **kwargs):
         super(BaseTestCase, self).__init__(*args, **kwargs)
 
@@ -42,6 +40,7 @@ class BaseTestCase(unittest2.TestCase,
     def setUpClass(cls):
         if hasattr(super(BaseTestCase, cls), 'setUpClass'):
             super(BaseTestCase, cls).setUpClass()
+        cls.config = config.FuelConfig()
 
 
 def call_until_true(func, duration, sleep_for):
@@ -77,6 +76,7 @@ class TestCase(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(TestCase, cls).setUpClass()
         cls.manager = cls.manager_class()
         for attr_name in cls.manager.client_attr_names:
             # Ensure that pre-existing class attributes won't be

--- a/fuel_health/tests/sanity/test_sanity_infrastructure.py
+++ b/fuel_health/tests/sanity/test_sanity_infrastructure.py
@@ -35,6 +35,7 @@ class SanityInfrastructureTest(nmanager.SanityChecksTest):
 
     @classmethod
     def setUpClass(cls):
+        super(SanityInfrastructureTest, cls).setUpClass()
         cls.controllers = cls.config.compute.controller_nodes
         cls.computes = cls.config.compute.compute_nodes
         cls.usr = cls.config.compute.controller_node_ssh_user


### PR DESCRIPTION
The presented patch provides several necessary lines of code that make it
possible to run the OSTF tests based on a config written in a file -the facility
which is currently needed for the Rally project. All the user has to do is to insert
an instruction like:

os.environ['CUSTOM_FUEL_CONFIG'] = 'path/to/config/file'

before the actual OSFT launch. Changing the FuelConfig() method
implementation as well as moving its call in the BaseTestCase class
into the setUpClass() method serves for this goal and ensures that
the config values will override the default ones.
