### PR TITLE
Fix invalid import

### DIFF
--- a/fuel_plugin/ostf_adapter/storage/migrations/env.py
+++ b/fuel_plugin/ostf_adapter/storage/migrations/env.py
@@ -13,7 +13,7 @@
 #    under the License.
 
 from __future__ import with_statement
-import logging
+import logging.config
 
 from sqlalchemy import engine_from_config, pool
 


### PR DESCRIPTION
Invalid import breaks migration scripts from running.

Without this change following error occurs:

```
$ alembic -c ./fuel_plugin/ostf_adapter/storage/alembic.ini upgrade head
Traceback (most recent call last):
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/bin/alembic", line 9, in <module>
    load_entry_point('alembic==0.7.4', 'console_scripts', 'alembic')()
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/config.py", line 399, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/config.py", line 393, in main
    self.run_cmd(cfg, options)
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/config.py", line 376, in run_cmd
    **dict((k, getattr(options, k)) for k in kwarg)
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/command.py", line 165, in upgrade
    script.run_env()
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/script.py", line 382, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/util.py", line 242, in load_python_file
    module = load_module_py(module_id, path)
  File "/home/rverchikov/Documents/ostf-fuel/ubuntu-venv/local/lib/python2.7/site-packages/alembic/compat.py", line 79, in load_module_py
    mod = imp.load_source(module_id, path, fp)
  File "fuel_plugin/ostf_adapter/storage/migrations/env.py", line 29, in <module>
    logging.config.fileConfig(config.config_file_name)
AttributeError: 'module' object has no attribute 'config'
```
